### PR TITLE
Create .gitattributes to fix GitHub Languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Benchmarks
+benchmarks/*.ipynb linguist-generated


### PR DESCRIPTION
This is a Julia Package and if you take a look at the repository at GitHub it shows as a Jupyter Notebook main repository:
![image](https://user-images.githubusercontent.com/43353831/138848741-84b21bb7-04a5-48f7-a17f-dabb5e561573.png)

This PR creates a `.gitattributes` file that marks `.ipynb` files inside the `benchmarks/` folder as `linguist-generated`.

This is similar to what I've done in `GeoStats.jl` in https://github.com/JuliaEarth/GeoStats.jl/pull/194 and https://github.com/JuliaEarth/GeoStats.jl/pull/196.

You can check the `.gitattributes` documentation [here](https://github.com/numpy/numpy/blob/main/.gitattributes).