### PR TITLE
Try DocumenterCodeBlocks.jl for nicer code highlighting

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,7 @@ Bibliography = "f1be7e48-bf82-45af-a471-ae754a193061"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterCodeBlocks = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
@@ -12,6 +13,9 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProbNumDiffEq = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[sources]
+DocumenterCodeBlocks = {url = "https://github.com/fredrikekre/DocumenterCodeBlocks.jl"}
 
 [compat]
 ModelingToolkit = "11"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,8 +14,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProbNumDiffEq = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[sources]
-DocumenterCodeBlocks = {url = "https://github.com/fredrikekre/DocumenterCodeBlocks.jl"}
-
 [compat]
+DocumenterCodeBlocks = "1"
 ModelingToolkit = "11"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,7 @@ using Documenter
 using ProbNumDiffEq
 
 using DocumenterCitations, Bibliography
+using DocumenterCodeBlocks
 
 # DocumenterCitations.bib_sorting(::Val{:numeric}) = :nyt
 # function DocumenterCitations.format_bibliography_label(
@@ -25,7 +26,7 @@ bib = CitationBibliography(
 sort_bibliography!(bib.entries, :nyt)  # name-year-title
 
 makedocs(
-    plugins=[bib],
+    plugins=[bib, CodeBlocks()],
     sitename="ProbNumDiffEq.jl",
     format=Documenter.HTML(
         assets=[


### PR DESCRIPTION
  ## Summary
  Documenter's default highlight.js-based highlighting handles Julia's syntax poorly (see e.g. the current [Getting Started](https://nathanaelbosch.github.io/ProbNumDiffEq.jl/stable/tutorials/getting_started/) page). This tries out [DocumenterCodeBlocks.jl](https://fredrikekre.github.io/DocumenterCodeBlocks.jl/dev/) (also being trialled in [Ferrite.jl#1415](https://github.com/Ferrite-FEM/Ferrite.jl/pull/1415)), which
  highlights code blocks at build time using JuliaSyntax.jl (the real Julia parser) instead, and additionally adds line numbers/permalinks and cross-reference links from code identifiers to their docstrings.

  - Added `DocumenterCodeBlocks` as a docs dependency, pulled via a `[sources]` entry since it isn't registered in the General registry yet.
  - Enabled it in `make.jl` via `plugins=[bib, CodeBlocks()]`.

  ## Test plan
  - [x] Built the docs locally end-to-end (`Pkg.develop` + `Pkg.instantiate` + `docs/make.jl`, mirroring CI's docs job) — builds cleanly, no new errors.
  - [x] Verified from a fresh `Manifest.toml` that `Pkg.instantiate()` resolves `DocumenterCodeBlocks` correctly via the `[sources]` entry (as CI would do it).
  - [x] Confirmed rendered HTML has real syntax-highlighting classes (`julia-keyword`, `julia-funcall`, `julia-string`, ...), line numbers, and `julia-ref` cross-reference links.
  - [ ] Visual review via this PR's `push_preview` deploy once CI runs — this is a draft specifically to get that preview link for review.

  Note: this is a draft in part because [Ferrite.jl's own trial PR](https://github.com/Ferrite-FEM/Ferrite.jl/pull/1415) is still in draft too, with an open CSS issue (inconsistent code-block font sizes on mobile) that's worth watching before merging here.